### PR TITLE
Add value property to examples iterator on param-table.nunjucks

### DIFF
--- a/templates/param-table.nunjucks
+++ b/templates/param-table.nunjucks
@@ -9,5 +9,5 @@
 {%- if param.format -%} **Format:** {{param.format}}. {% endif -%}
 {{ param.description }}
 {%- if param.examples -%}**Examples:** {% for example in param.examples -%}
-{%- set comma = joiner() %}{{ comma() }} `{{ example }}`
+{%- set comma = joiner() %}{{ comma() }} `{{ example.value }}`
 {%- endfor %}. {% endif %}

--- a/templates/param-table.nunjucks
+++ b/templates/param-table.nunjucks
@@ -8,6 +8,6 @@
 {%- endfor %}. {% endif %}
 {%- if param.format -%} **Format:** {{param.format}}. {% endif -%}
 {{ param.description }}
-{%- if param.examples -%}**Examples:** {% for example in param.examples -%}
+{%- if param.examples %} **Examples:** {% for example in param.examples -%}
 {%- set comma = joiner() %}{{ comma() }} `{{ example.value }}`
 {%- endfor %}. {% endif %}


### PR DESCRIPTION
The generation of examples had this result: 

> Examples: [object Object]

Now it's as expected: 

> Examples: demo