### PR TITLE
add support for array type info

### DIFF
--- a/templates/param-table.nunjucks
+++ b/templates/param-table.nunjucks
@@ -2,7 +2,8 @@
 {%- if param.type == 'object' -%}
 {%- set type_name = param.rawType.name -%}
 [{{ type_name }}](#{{ getSafeId(type_name) }})
-{%- else %} {{ param.type }}{%- endif %} | {{ param.required }} | 
+{%- else %} {{ param.type }} {{ "of [**" + param.items.name + "**](#" + param.items.name + ")" if param.type == 'array' and param.items.name != undefined }}
+{%- endif %} | {{ param.required }} |
 {%- if param.enum -%}**One of:** {%- for value in param.enum -%}
 {%- set comma = joiner() %}{{ comma() }} `{{ value }}`
 {%- endfor %}. {% endif %}

--- a/templates/types.nunjucks
+++ b/templates/types.nunjucks
@@ -6,6 +6,12 @@
 
 ## {{ type.displayName }}
 
+> **TYPE DEFINITION** 
+
+```json 
+{{ type.content }}  
+``` 
+
 {{ type.description }}
 
 **Parent type:** {{ type.type }} {{ "of [**" + type.items.name + "**](#" + type.items.name + ")" if type.type == 'array' and type.items.name != undefined }}

--- a/templates/types.nunjucks
+++ b/templates/types.nunjucks
@@ -6,7 +6,7 @@
 
 ## {{ type.displayName }}
 
-> **TYPE DEFINITION** 
+> **TYPE DEFINITION**
 
 ```json
 {{ type.content }}

--- a/templates/types.nunjucks
+++ b/templates/types.nunjucks
@@ -8,9 +8,9 @@
 
 > **TYPE DEFINITION** 
 
-```json 
-{{ type.content }}  
-``` 
+```json
+{{ type.content }}
+```
 
 {{ type.description }}
 

--- a/templates/types.nunjucks
+++ b/templates/types.nunjucks
@@ -6,15 +6,9 @@
 
 ## {{ type.displayName }}
 
-> **TYPE DEFINITION**
-
-```json
-{{ type.content }}
-```
-
 {{ type.description }}
 
-**Parent type:** {{ type.type }}
+**Parent type:** {{ type.type }} {{ "of [**" + type.items.name + "**](#" + type.items.name + ")" if type.type == 'array' and type.items.name != undefined }}
 
     {% if type.enum | length != 0 %}
 **Possible values:**


### PR DESCRIPTION
Generation of array:

> | property | array  | true |

Now:

> | property | array of [**type**](#type) | true |